### PR TITLE
User gets notified when off-topic comment is moved

### DIFF
--- a/actions/discussion/offtopic.php
+++ b/actions/discussion/offtopic.php
@@ -45,5 +45,24 @@ $warning_text = elgg_echo('cg:form:offtopic:warning');
 $reply->description = "[{$warning_text} {$link}]";
 $reply->save();
 
+$user = get_user($user_guid);
+$site = elgg_get_site_entity();
+
+$subject = elgg_echo('cg:forum:offtopic:notify:title', array(), $user->language);
+$message = elgg_echo('cg:forum:offtopic:notify:body', array(
+	$user->name,
+	$site->name,
+	elgg_get_excerpt($grouptopic->description, 80),
+	$grouptopic->getURL(),
+), $user->language);
+
+// Let the user know that the comment was moved
+notify_user($user_guid, $site->guid, $subject, $message,
+	array(
+		'action' => 'move',
+		'object' => $grouptopic,
+	)
+);
+
 system_message(elgg_echo('cg:forum:offtopic:success'));
 forward($grouptopic->getURL());

--- a/languages/en.php
+++ b/languages/en.php
@@ -19,6 +19,13 @@ return array(
 	'cg:forum:offtopic:success' => "Successfully move to new topic",
 	'cg:form:offtopic:warning' => "Moderator: this comment was off-topic. It was moved to its own topic.",
 	'cg:form:offtopic:warning:link' => "Read it here.",
+	'cg:forum:offtopic:notify:title' => 'Your comment has been moved ',
+	'cg:forum:offtopic:notify:body' => 'Hi %s
+
+The administrators at %s have promoted your comment "%s" into its own separate discusson thread.
+
+You can find the new topic here:
+%s',
 
 	'cg:tabs:categorize' => 'Categorize',
 	'cg:tabs:combine' => 'Combine groups',


### PR DESCRIPTION
Don't merge. I haven't tested this yet.

I wonder which one would be better approach for the tone of the message:
 - Your comment was off-topic. Shame on you!
 - We thought that your comment deserved its very own awesome thread!

The latter one is probably better. :)